### PR TITLE
Run as relx release

### DIFF
--- a/blog/rebar.config
+++ b/blog/rebar.config
@@ -5,3 +5,15 @@
   % {config, "config/sys.config"},
     {apps, [blog]}
 ]}.
+
+{plugins, [
+    rebar3_run
+]}.
+
+{relx, [{release, {blog, "1.0"},
+         [blog]},
+
+        {dev_mode, true},
+        {include_erts, false},
+
+        {extended_start_script, true}]}.

--- a/blog/src/blog.app.src
+++ b/blog/src/blog.app.src
@@ -5,7 +5,8 @@
   {mod, {blog_app, []}},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    pcsc
    ]},
   {env,[]},
   {modules, []},

--- a/blog/src/blog.erl
+++ b/blog/src/blog.erl
@@ -1,6 +1,0 @@
--module(blog).
--export([main/1]).
-
-main(X) ->
-	io:fwrite("Hello world!\n"),
-	pcsc_card_db:list_readers().

--- a/blog/src/blog_app.erl
+++ b/blog/src/blog_app.erl
@@ -10,6 +10,9 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
+    io:fwrite("List of available readers:\n"),
+    {ok, Readers} = pcsc_card_db:list_readers(),
+    erlang:display(Readers),
     blog_sup:start_link().
 
 stop(_State) ->


### PR DESCRIPTION
implements a way to run the erlang sample with a one-liner using relx and relx_run.

when running via rebar3 run the app is started by calling blog_app:start
the original PoC code was added to this function and prints a list
of readers found.

there might be a better way to implement the poc, but unfortunately I'm no erlang expert.

see also https://elixirforum.com/t/how-to-access-pcsc-card-readers-via-erlang-elixir/19789/5